### PR TITLE
WIP Updated Docker base image for Concourse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update -y && apt-get install -y python3.7 python3-distutils python3-
 # Python 3 encoding set
 ENV LANG C.UTF-8
 
+# Set Python priority to use v3.7
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+
+# Symlink pip and python to use v3
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip
+
 # install terraform
 WORKDIR /tmp
 
@@ -24,5 +32,6 @@ RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_V
     curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_{$TF_VERSION}_SHA256SUMS -o terraform.sha && \
         echo if [ $(sha256sum -c terraform.sha 2>/dev/null | grep OK | wc -l) -eq 1 ]; then echo 'Terraform file integrity is good'; unzip terraform_${TF_VERSION}_linux_amd64.zip && mv terraform /usr/bin/terraform && rm terraform_${TF_VERSION}_linux_amd64.zip terraform.sha;fi
 
+# Copy over AWS STS AssumeRole scripts
 COPY bin /usr/local/bin
 RUN chmod +x /usr/local/bin/*.sh

--- a/bin/sts-assume-role.sh
+++ b/bin/sts-assume-role.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-set -e
-
-unset AWS_SESSION_TOKEN
+# Reset to the lambda session credentials to the exec role
+if [[ -n "$ASSUMED_SESSION" ]]; then
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+  unset AWS_SESSION_TOKEN
+  unset ASSUMED_SESSION
+fi
 
 role_arn="$1"
 region="$2"
@@ -10,6 +14,9 @@ temp_role=$(aws sts assume-role \
                     --role-arn "${role_arn}" \
                     --role-session-name "concourse-task" \
                     --duration 1800)
+
+# Store the lambda exec role AWS credentials to be restored
+export ASSUMED_SESSION="true"
 
 export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
 export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)


### PR DESCRIPTION
- some pipelines use pip and python which isn't linked to v3.7
- updated sts-assume-role.sh script, required for example for cyber-security-cloudwatch-config Concourse deploy

Solo: @gds-ahine