### PR TITLE
Cloudwatch health

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ To extend upon the main image, use `FROM gdscyber/cyber-security-concourse-base-
 # other base images
 
 There are a number of different directories in this repository which contain different base images that are generic and can be reused but do not use the base image for the reasons mentioned above.
+
+# Dockerfiles that use the base image
+
+Other repositories that use this base image will contain their own Dockerfile in the project repo. The pipeline within this repository will check for changes to those Dockerfiles and update them in docker hub so they are always up to date.

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -23,6 +23,15 @@ resources:
         - Dockerfile
       uri: https://github.com/alphagov/cyber-security-security-advisory-dashboard.git
 
+  - name: cloudwatch-health-image-git
+    type: git
+    source:
+      branch: master
+      paths:
+        - docker/concourse-worker-health/Dockerfile
+      uri: https://github.com/alphagov/cyber-security-cloudwatch-config.git
+
+
   - name: concourse-base-image-docker-hub
     type: registry-image
     source: &build-image-source
@@ -41,6 +50,12 @@ resources:
     source:
       <<: *build-image-source
       repository: gdscyber/sec_adv
+
+  - name: cloudwatch-health-image-docker-hub
+    type: registry-image
+    source:
+      <<: *build-image-source
+      repository: gdscyber/concourse-worker-health
 
 jobs:
   - name: build_base_docker_image
@@ -114,5 +129,29 @@ jobs:
           path: build
 
     - put: github-security-dashboard-image-docker-hub
+      params:
+        image: image/image.tar
+
+
+  - name: cloudwatch_health_docker_image
+    serial: false
+    plan:
+    - get: cloudwatch-health-image-git
+      trigger: true
+
+    - task: build
+      privileged: true
+      config:
+        <<: *build-image-config
+        params:
+          CONTEXT: cloudwatch-health-image-git/docker/concourse-worker-health/
+        inputs:
+        - name: cloudwatch-health-image-git
+        outputs:
+        - name: image
+        run:
+          path: build
+
+    - put: cloudwatch-health-image-docker-hub
       params:
         image: image/image.tar


### PR DESCRIPTION
Changes already pushed to concourse.

This PR adds a build task whenever it detects changes to the cloudwatch health Dockerfile in the remote repo. There is also a small change to the main README to account for remote repos.