### PR TITLE
Update Dockerfile to use Python 3.7 headers and venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ LABEL user="gdscyber"
 LABEL Name="cyber_concourse_pipeline"
 LABEL Version=0.0.1
 
-RUN apt-get update -y && apt-get install -y python3.7 python3.8 python3.8-dev python3-distutils python3-pip build-essential libssl-dev libffi-dev python3-dev python3.7-venv awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
+RUN apt-get update -y && apt-get install -y python3.8 python3.8-dev python3-distutils python3-pip build-essential libssl-dev libffi-dev python3-dev python3.8-venv awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
 
 # Python 3 encoding set
 ENV LANG C.UTF-8
 
-# Set Python priority to use v3.7
+# Set Python priority to use v3.8
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
 
 # Symlink pip and python to use v3
 RUN ln -s /usr/bin/python3 /usr/bin/python && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@ LABEL user="gdscyber"
 LABEL Name="cyber_concourse_pipeline"
 LABEL Version=0.0.1
 
-RUN apt-get update -y && apt-get install -y python3.8 python3.8-dev python3-distutils python3-pip build-essential libssl-dev libffi-dev python3-dev python3.8-venv awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
+RUN apt-get update -y && apt-get install -y python3.7 python3.7-dev python3-distutils python3-pip build-essential libssl-dev libffi-dev python3-dev python3.7-venv awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
 
 # Python 3 encoding set
 ENV LANG C.UTF-8
 
-# Set Python priority to use v3.8
+# Set Python priority to use v3.7
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 2
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
 
 # Symlink pip and python to use v3
 RUN ln -s /usr/bin/python3 /usr/bin/python && \


### PR DESCRIPTION
EDIT:
I've downgraded this to python 3.7 after discussion with @akinnane 
- @0atman

----

I would really like a review on this to make sure this doesn't break any of our Concourse pipelines that we already have.

I imagine it shouldn't, because we (should) use `python` or `python3` in our scripts instead of explicitly referring to `python3.7`.

Motivation:

There was a previous change which installed `python3.8-dev`, and though it might have worked for some things, I found in an issue (see https://github.com/alphagov/cyber-security-api/issues/37#issuecomment-656648127) that the fact that Python 3.7 was still being used was causing issues when trying to manually compile Python packages with `pip wheel` (which, for some packages, is necessary for deploying Lambdas via Chalice).

This should hopefully streamline a few things.