### PR TITLE
Update Dockerfile for Python 3.8 use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM python:3.8
 
 ENV TF_VERSION 0.12.26
 
@@ -6,31 +6,20 @@ ENV TF_VERSION 0.12.26
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-LABEL ubuntu="18.04"
 LABEL terraform="$TF_VERSION"
 LABEL user="gdscyber"
 LABEL Name="cyber_concourse_pipeline"
 LABEL Version=0.0.1
 
-RUN apt-get update -y && apt-get install -y python3.7 python3.7-dev python3-distutils python3-pip build-essential libssl-dev libffi-dev python3-dev python3.7-venv awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
+RUN apt-get update -y && apt-get install -y build-essential libssl-dev libffi-dev awscli jq curl unzip git musl musl-dev musl-tools zip ca-certificates gcc libc6-dev wget && apt-get clean
 
 # Python 3 encoding set
 ENV LANG C.UTF-8
 
-# Set Python priority to use v3.7
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
-
-# Symlink pip and python to use v3
-RUN ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip
-
 # install terraform
+ADD install_terraform.sh /tmp/install_terraform.sh
 WORKDIR /tmp
-
-RUN curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -o terraform_${TF_VERSION}_linux_amd64.zip && \
-    curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_{$TF_VERSION}_SHA256SUMS -o terraform.sha && \
-        echo if [ $(sha256sum -c terraform.sha 2>/dev/null | grep OK | wc -l) -eq 1 ]; then echo 'Terraform file integrity is good'; unzip terraform_${TF_VERSION}_linux_amd64.zip && mv terraform /usr/bin/terraform && rm terraform_${TF_VERSION}_linux_amd64.zip terraform.sha;fi
+RUN bash install_terraform.sh
 
 # Copy over AWS STS AssumeRole scripts
 COPY bin /usr/local/bin

--- a/install_terraform.sh
+++ b/install_terraform.sh
@@ -1,0 +1,9 @@
+cd /tmp
+curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip -o terraform_${TF_VERSION}_linux_amd64.zip
+curl https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_{$TF_VERSION}_SHA256SUMS -o terraform.sha
+if [ $(sha256sum -c terraform.sha 2>/dev/null | grep OK | wc -l) -eq 1 ]; then
+    echo 'Terraform file integrity is good'
+    unzip terraform_${TF_VERSION}_linux_amd64.zip
+    mv terraform /usr/bin/terraform
+    rm terraform_${TF_VERSION}_linux_amd64.zip terraform.sha
+fi


### PR DESCRIPTION
We would like to make an alternate tag for the Cyber base image for use with Python 3.8.

This is because we are having difficulty building certain Python projects for use in AWS Lambda using Python 3.7 - the runtime for Python 3.7 Lambdas is Amazon Linux 1 (see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html), but an Amazon Linux 1 Docker image does not have the necessary libraries for building wheels of Python 3.7 packages. Not only does Python 3.8 run on Amazon Linux 2, but Amazon Linux 2 Docker images have the libraries that the older version lacks.

The problem is that we would like to use the Cyber base image for things like testing, packaging and deploying with Terraform, but since the image is based on Python 3.7 we can't be sure that it will work correctly for projects that use Python 3.8. This is the motivation behind this change.

However, we don't want to disrupt existing uses of the image for 3.7 projects, so we propose creating a `python38` (or similar) tag so that this is an alternative to the current image, and they can be used side by side as we migrate projects over to Python 3.8.

# Technical notes

The Dockerfile has been changed so that it is no longer based on Ubuntu 18.04, because installing packages such as `python3-pip` prompts an installation of Python 3.6 alongside 3.8. Instead we use the official Python 3.8 image, which is based on Debian Buster.

We have also moved the Terraform installation lines to a separate bash script, as they were causing errors in their existing form inside the Dockerfile (and also for readability's sake).