### PR TITLE
Take ownership of behave image

### DIFF
--- a/concourse-chrome-driver/Dockerfile
+++ b/concourse-chrome-driver/Dockerfile
@@ -1,0 +1,20 @@
+FROM amazonlinux:2
+
+WORKDIR /usr/src/app
+RUN yum install -y apt-utils zip unzip make
+RUN yum install -y python3.7 python3-distutils python3-pip
+RUN yum install -y curl tar imagemagick python-gtk2
+RUN yum install -y libpng libtiff fontconfig freetype libX11
+
+# Install chromedriver and headless-chrome
+RUN mkdir ./bin
+COPY bin/* ./bin/
+RUN bash bin/install_chrome.sh
+
+ENV PATH=.:/opt:$PATH
+
+# Install python deps
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY . .

--- a/concourse-chrome-driver/README.md
+++ b/concourse-chrome-driver/README.md
@@ -1,0 +1,13 @@
+# Docker container for behave
+
+# Building the docker container 
+
+
+```
+# NOTE: Replace version with the bumped version number
+docker build --no-cache -t gdscyber/concourse-chrome-driver -t gdscyber/concourse-chrome-driver:1.0 .
+
+# Then to push to DockerHub:
+docker push gdscyber/concourse-chrome-driver:1.0
+docker push gdscyber/concourse-chrome-driver:latest 
+```

--- a/concourse-chrome-driver/README.md
+++ b/concourse-chrome-driver/README.md
@@ -2,7 +2,6 @@
 
 # Building the docker container 
 
-
 ```
 # NOTE: Replace version with the bumped version number
 docker build --no-cache -t gdscyber/concourse-chrome-driver -t gdscyber/concourse-chrome-driver:1.0 .

--- a/concourse-chrome-driver/bin/install_chrome.sh
+++ b/concourse-chrome-driver/bin/install_chrome.sh
@@ -12,6 +12,7 @@ unzip headless-chromium.zip
 rm headless-chromium.zip
 ln -fs /opt/headless-chromium /opt/chrome
 
+## This method installs a normal chrome stable release which can be used in --headless mode
 #touch /etc/yum.repos.d/google-chrome.repo
 #echo -e "[google-chrome]\nname=google-chrome\nbaseurl=http://dl.google.com/linux/chrome/rpm/stable/\$basearch\nenabled=1\ngpgcheck=1\ngpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub" >> /etc/yum.repos.d/google-chrome.repo
 #touch /etc/yum.repos.d/centos.repo

--- a/concourse-chrome-driver/bin/install_chrome.sh
+++ b/concourse-chrome-driver/bin/install_chrome.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+CHROME_DRIVER_VERSION=86.0.4240.22
+HEADLESS_CHROME_VERSION=v1.0.0-57
+
+cd /opt
+curl -SL https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip > chromedriver.zip
+unzip chromedriver.zip
+rm chromedriver.zip
+# download chrome binary
+curl -SL https://github.com/adieuadieu/serverless-chrome/releases/download/${HEADLESS_CHROME_VERSION}/stable-headless-chromium-amazonlinux-2.zip > headless-chromium.zip
+unzip headless-chromium.zip
+rm headless-chromium.zip
+ln -fs /opt/headless-chromium /opt/chrome
+
+#touch /etc/yum.repos.d/google-chrome.repo
+#echo -e "[google-chrome]\nname=google-chrome\nbaseurl=http://dl.google.com/linux/chrome/rpm/stable/\$basearch\nenabled=1\ngpgcheck=1\ngpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub" >> /etc/yum.repos.d/google-chrome.repo
+#touch /etc/yum.repos.d/centos.repo
+#echo -e "[CentOS-base]\nname=CentOS-6 - Base\nmirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=os\ngpgcheck=1\ngpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6\n\n" >> /etc/yum.repos.d/centos.repo
+#echo -e "#released updates\n[CentOS-updates]\nname=CentOS-6 - Updates\nmirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=updates\ngpgcheck=1\ngpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6\n\n" >> /etc/yum.repos.d/centos.repo
+#echo -e "#additional packages that may be useful\n[CentOS-extras]\nname=CentOS-6 - Extras\nmirrorlist=http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=extras\ngpgcheck=1\ngpgkey=http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6\n" >> /etc/yum.repos.d/centos.repo
+#yum install -y google-chrome-stable
+## google-chrome-stable --version
+## which google-chrome-stable
+#ln -fs /usr/bin/google-chrome-stable /opt/chrome

--- a/concourse-chrome-driver/requirements.txt
+++ b/concourse-chrome-driver/requirements.txt
@@ -1,0 +1,3 @@
+behave==1.2.6
+requests==2.23.0
+selenium==3.141.0

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -2,14 +2,17 @@
 health_status_notify: &health_status_notify
   put: health-notification
 
+blocks:
+  docker-creds: &docker-creds
+    username: ((dockerhub_username))
+    password: ((dockerhub_password))
 
 resource_types:
   - name: http-api
     type: docker-image
     source:
       repository: gdscyber/http-api-resource
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
 
 resources:
   - name: health-notification
@@ -107,66 +110,51 @@ resources:
 
   - name: concourse-base-image-docker-hub
     type: registry-image
-    source: &build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+    source:
+      <<: *docker-creds
       repository: gdscyber/cyber-security-concourse-base-image
 
   - name: concourse-base-image-docker-hub-amazonlinux2
     type: registry-image
     source:
-      <<: *build-image-source
+      <<: *docker-creds
       tag: amazonlinux2
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
       repository: gdscyber/cyber-security-concourse-base-image
 
   - name: load-testing-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/artillery-load-testing
 
   - name: github-security-dashboard-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/sec_adv
 
   - name: cloudwatch-health-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/concourse-worker-health
 
   - name: gsuite-splunk-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/gsuite-splunk
 
   - name: salesforce-splunk-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/salesforce-splunk
 
   - name: csls-image-docker-hub
     type: registry-image
     source:
-      <<: *build-image-source
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
+      <<: *docker-creds
       repository: gdscyber/csls-concourse
 
 jobs:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -8,7 +8,8 @@ resource_types:
     type: docker-image
     source:
       repository: gdscyber/http-api-resource
-
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
 
 resources:
   - name: health-notification
@@ -40,7 +41,7 @@ resources:
     source:
       branch: master
       paths:
-        - amazonlinux2/Dockerfile
+        - amazonlinux2/
       uri: https://github.com/alphagov/cyber-security-concourse-base-image.git
 
   - name: load-testing-image-git
@@ -49,6 +50,14 @@ resources:
       branch: master
       paths:
         - load_testing/Dockerfile
+      uri: https://github.com/alphagov/cyber-security-concourse-base-image.git
+
+  - name: concourse-chrome-driver-image-git
+    type: git
+    source:
+      branch: master
+      paths:
+        - concourse-chrome-driver/
       uri: https://github.com/alphagov/cyber-security-concourse-base-image.git
 
   - name: github-security-dashboard-image-git
@@ -78,6 +87,15 @@ resources:
         - gds-gsuite-govuk-paas/bin/*
       uri: git@github.com:alphagov/cyber-security-splunk-apps.git
 
+  - name: salesforce-splunk-image-git
+    type: git
+    source:
+      branch: master
+      private_key: ((gsuite-splunk-private-key))
+      paths:
+        - gds-salesforce-forwarder-paas/
+      uri: git@github.com:alphagov/cyber-security-splunk-apps.git
+
   - name: csls-image-git
     type: git
     source:
@@ -99,36 +117,56 @@ resources:
     source:
       <<: *build-image-source
       tag: amazonlinux2
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/cyber-security-concourse-base-image
 
   - name: load-testing-image-docker-hub
     type: registry-image
     source:
       <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/artillery-load-testing
 
   - name: github-security-dashboard-image-docker-hub
     type: registry-image
     source:
       <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/sec_adv
 
   - name: cloudwatch-health-image-docker-hub
     type: registry-image
     source:
       <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/concourse-worker-health
 
   - name: gsuite-splunk-image-docker-hub
     type: registry-image
     source:
       <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/gsuite-splunk
+
+  - name: salesforce-splunk-image-docker-hub
+    type: registry-image
+    source:
+      <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
+      repository: gdscyber/salesforce-splunk
 
   - name: csls-image-docker-hub
     type: registry-image
     source:
       <<: *build-image-source
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
       repository: gdscyber/csls-concourse
 
 jobs:
@@ -232,10 +270,6 @@ jobs:
     plan:
       - get: concourse-base-image-git-amazonlinux2
         trigger: true
-      - get: concourse-base-image-git
-        trigger: true
-        passed:
-        - build-load-testing-docker-image
       - task: build
         privileged: true
         config:
@@ -287,7 +321,7 @@ jobs:
       - get: concourse-base-image-git
         trigger: true
         passed:
-        - build-base-docker-image-amazonlinux2
+        - build-load-testing-docker-image
       - task: build
         privileged: true
         config:
@@ -324,7 +358,6 @@ jobs:
           params:
             message: "GitHub security dashboard image Docker Hub upload failed."
             health: unhealthy
-
 
   - name: cloudwatch-health-docker-image
     serial: false
@@ -422,16 +455,12 @@ jobs:
             message: "CSLS image Docker Hub upload failed."
             health: unhealthy
 
-
+  # base-image: splunk/splunk
   - name: build-gsuite-splunk-docker-image
     serial: false
     plan:
       - get: gsuite-splunk-image-git
         trigger: true
-      - get: concourse-base-image-git
-        trigger: true
-        passed:
-        - csls-docker-image
       - task: build
         privileged: true
         config:
@@ -467,4 +496,90 @@ jobs:
           <<: *health_status_notify
           params:
             message: "Gsuite splunk image Docker Hub upload failed."
+            health: unhealthy
+
+  # base-image: splunk/splunk
+  - name: build-salesforce-splunk-docker-image
+    serial: false
+    plan:
+      - get: salesforce-splunk-image-git
+        trigger: true
+      - task: build
+        privileged: true
+        config:
+          <<: *build-image-config
+          params:
+            CONTEXT: salesforce-splunk-image-git/gds-salesforce-forwarder-paas/
+          inputs:
+            - name: salesforce-splunk-image-git
+          outputs:
+            - name: image
+          run:
+            path: build
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Salesforce splunk image build completed successfully."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Salesforce splunk image build failed."
+            health: unhealthy
+
+      - put: salesforce-splunk-image-docker-hub
+        params:
+          image: image/image.tar
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Salesforce splunk image Docker Hub upload completed successfully."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Salesforce splunk image Docker Hub upload failed."
+            health: unhealthy
+
+  # base-image: amazonlinux
+  - name: build-concourse-chrome-driver-docker-image
+    serial: false
+    plan:
+      - get: concourse-chrome-driver-image-git
+        trigger: true
+      - task: build
+        privileged: true
+        config:
+          <<: *build-image-config
+          params:
+            CONTEXT: concourse-chrome-driver-image-git/
+          inputs:
+            - name: concourse-chrome-driver-image-git
+          outputs:
+            - name: image
+          run:
+            path: build
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Concourse chrome driver image build completed successfully."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Concourse chrome driver image build failed."
+            health: unhealthy
+
+      - put: concourse-chrome-driver-image-docker-hub
+        params:
+          image: image/image.tar
+        on_success:
+          <<: *health_status_notify
+          params:
+            message: "Concourse chrome driver image Docker Hub upload completed successfully."
+            health: healthy
+        on_failure:
+          <<: *health_status_notify
+          params:
+            message: "Concourse chrome driver image Docker Hub upload failed."
             health: unhealthy


### PR DESCRIPTION
This is primarily about taking ownership of the concourse-chrome-driver container which is ours but was in the VPS (transfer-coronavirus-data-service) repo. 

In doing that I've upgraded headless chrome and chrome driver to current stable versions which also meant changing from an ubuntu base to amazonlinux. This probably needs some more work to get the container size back down. 

I've added the container build to the pipeline. 
I've also added the container build for the salesforce forwarder since that's in up next on the board so I thought I might as well get it done. 

I've removed the serial triggering for the 2 splunk containers and the concourse chrome driver image since they don't 
extend the base image. 

I've refactored the anchor block for the creds so it's declared once with just the creds in it. I've not tested that yet. 

