### PR TITLE
Fix context for concourse-chrome-driver

### DIFF
--- a/concourse-chrome-driver/concourse/pipeline.yml
+++ b/concourse-chrome-driver/concourse/pipeline.yml
@@ -76,7 +76,7 @@ jobs:
             source:
               repository: vito/oci-build-task
           params:
-            CONTEXT: concourse-chrome-driver-image-git/
+            CONTEXT: concourse-chrome-driver-image-git/concourse-chrome-driver/
           inputs:
             - name: concourse-chrome-driver-image-git
           outputs:


### PR DESCRIPTION
The latest image has the root of the repository set as the context.

This change updates the context to the concourse-chrome-driver directory.