### PR TITLE
Use the shared team-wide docker_hub_ credentials.

### DIFF
--- a/concourse-chrome-driver/concourse/pipeline.yml
+++ b/concourse-chrome-driver/concourse/pipeline.yml
@@ -4,8 +4,8 @@ health_status_notify: &health_status_notify
 
 blocks:
   docker-creds: &docker-creds
-    username: ((dockerhub_username))
-    password: ((dockerhub_password))
+    username: ((docker_hub_username))
+    password: ((docker_hub_password))
 
 resource_types:
   - name: http-api

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -4,8 +4,8 @@ health_status_notify: &health_status_notify
 
 blocks:
   docker-creds: &docker-creds
-    username: ((dockerhub_username))
-    password: ((dockerhub_password))
+    username: ((docker_hub_username))
+    password: ((docker_hub_password))
 
 resource_types:
   - name: http-api


### PR DESCRIPTION
I think the base image pipeline may have pipeline specific
credentials which we should get rid of.