### PR TITLE
Remove security advisory container build.

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -63,14 +63,6 @@ resources:
         - load_testing/Dockerfile
       uri: https://github.com/alphagov/cyber-security-concourse-base-image.git
 
-  - name: github-security-dashboard-image-git
-    type: git
-    source:
-      branch: master
-      paths:
-        - Dockerfile
-      uri: https://github.com/alphagov/cyber-security-security-advisory-dashboard.git
-
   - name: cloudwatch-health-image-git
     type: git
     source:
@@ -157,13 +149,6 @@ resources:
     source:
       <<: *docker-creds
       repository: gdscyber/artillery-load-testing
-      tag: latest
-
-  - name: github-security-dashboard-image-docker-hub
-    type: registry-image
-    source:
-      <<: *docker-creds
-      repository: gdscyber/sec_adv
       tag: latest
 
   - name: cloudwatch-health-image-docker-hub
@@ -371,55 +356,6 @@ jobs:
           <<: *health_status_notify
           params:
             message: "Cyber security concourse base image (Amazon Linux 2) Docker Hub upload failed."
-            health: unhealthy
-
-
-  - name: build-github-security-dashboard-docker-image
-    serial: false
-    plan:
-      - get: github-security-dashboard-image-git
-        trigger: true
-
-      - get: concourse-base-image-git
-        trigger: true
-        passed:
-          - build-base-docker-image
-
-      - task: build
-        privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: github-security-dashboard-image-git/
-          inputs:
-            - name: github-security-dashboard-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
-        on_success:
-          <<: *health_status_notify
-          params:
-            message: "GitHub security dashboard image build completed successfully."
-            health: healthy
-        on_failure:
-          <<: *health_status_notify
-          params:
-            message: "GitHub security dashboard image build failed."
-            health: unhealthy
-
-      - put: github-security-dashboard-image-docker-hub
-        params:
-          image: image/image.tar
-        on_success:
-          <<: *health_status_notify
-          params:
-            message: "GitHub security dashboard image Docker Hub upload completed successfully."
-            health: healthy
-        on_failure:
-          <<: *health_status_notify
-          params:
-            message: "GitHub security dashboard image Docker Hub upload failed."
             health: unhealthy
 
   - name: cloudwatch-health-docker-image


### PR DESCRIPTION
All this container does is install the requirements file.

It's only triggered by changes to the Dockerfile.

That means that when requirements are changed the tests in the sec advisories pipeline are not being run with the new dependencies.