### PR TITLE
Upgrade default node version to current stable release ^

### DIFF
--- a/load_testing/Dockerfile
+++ b/load_testing/Dockerfile
@@ -4,10 +4,14 @@ RUN apt-get update -y && \
         apt-get install -y nodejs npm && \
         apt-get clean
 
+# Upgrade default ubuntu node version to current stable version
+RUN npm install -g n
+RUN n stable
+
 RUN npm install -g \
         artillery \
         artillery-engine-kinesis
-        
+
 RUN mkdir -p /node_modules/artillery/bin && \
     ln -s /usr/local/bin/artillery \
         /node_modules/artillery/bin/artillery


### PR DESCRIPTION
I've tested node is installed and upgraded but I've not tested artillery works - Not sure how to run it locally but I assume it will get caught in the pipeline if it doesn't. 

`n` is pyenv for node and `n stable` installs the latest stable release of node and npm which I think is currently `14.7`

I guess the other thing we should probably do is upgrade ubuntu to 20.04 but I think it still has a very outdated default node version.