### PR TITLE
Replace anchor block with sub-task file for container builds

### DIFF
--- a/build-container.yml
+++ b/build-container.yml
@@ -5,13 +5,12 @@ image_resource:
     repository: vito/oci-build-task
     username: ((docker_hub_username))
     password: ((docker_hub_password))
-
 params:
   DOCKERFILE:
   CONTEXT:
-
+inputs:
+  - name: csw-image-git
 outputs:
-- name: image
-
+  - name: image
 run:
   path: build

--- a/build-container.yml
+++ b/build-container.yml
@@ -1,0 +1,17 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: vito/oci-build-task
+    username: ((docker_hub_username))
+    password: ((docker_hub_password))
+
+params:
+  DOCKERFILE:
+  CONTEXT:
+
+outputs:
+- name: image
+
+run:
+  path: build

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -222,20 +222,12 @@ jobs:
 
       - task: build
         privileged: true
-        config: &build-image-config
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: vito/oci-build-task
-          params:
-            CONTEXT: concourse-base-image-git/
-          inputs:
-            - name: concourse-base-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: concourse-base-image-git/
+          DOCKERFILE: concourse-base-image-git/Dockerfile
+        inputs:
+          - name: concourse-base-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -246,7 +238,6 @@ jobs:
           params:
             message: "Cyber security concourse base image build failed."
             health: unhealthy
-
 
       - put: concourse-base-image-docker-hub
         params:
@@ -276,16 +267,12 @@ jobs:
 
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: load-testing-image-git/load_testing
-          inputs:
-            - name: load-testing-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: load-testing-image-git/load_testing
+          DOCKERFILE: load-testing-image-git/load_testing/Dockerfile
+        inputs:
+          - name: load-testing-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -314,24 +301,19 @@ jobs:
   - name: build-base-docker-image-amazonlinux2
     serial: false
     plan:
+      - get: concourse-base-image-git
+        trigger: false
+
       - get: concourse-base-image-git-amazonlinux2
         trigger: true
+
       - task: build
         privileged: true
-        config:
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: vito/oci-build-task
-          params:
-            CONTEXT: concourse-base-image-git-amazonlinux2/amazonlinux2
-          inputs:
-            - name: concourse-base-image-git-amazonlinux2
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-iamge-git/build-container.yml
+        params:
+          CONTEXT: concourse-base-image-git-amazonlinux2/amazonlinux2
+        inputs:
+          - name: concourse-base-image-git-amazonlinux2
         on_success:
           <<: *health_status_notify
           params:
@@ -342,7 +324,6 @@ jobs:
           params:
             message: "Cyber security concourse base image (Amazon Linux 2) build failed."
             health: unhealthy
-
 
       - put: concourse-base-image-docker-hub-amazonlinux2
         params:
@@ -372,16 +353,12 @@ jobs:
 
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: cloudwatch-health-image-git/docker/concourse-worker-health/
-          inputs:
-            - name: cloudwatch-health-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: cloudwatch-health-image-git/docker/concourse-worker-health/
+          DOCKERFILE: cloudwatch-health-image-git/docker/concourse-worker-health/Dockerfile
+        inputs:
+          - name: cloudwatch-health-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -421,20 +398,11 @@ jobs:
 
       - task: build
         privileged: true
-        config: &build-image-config
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: vito/oci-build-task
-          params:
-            DOCKERFILE: csls-image-git/config/concourse/Dockerfile
-          inputs:
-            - name: csls-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        params:
+          CONTEXT: csls-image-git/config/concourse/
+          DOCKERFILE: csls-image-git/config/concourse/Dockerfile
+        inputs:
+          - name: csls-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -468,16 +436,11 @@ jobs:
         trigger: true
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: gsuite-splunk-image-git/gds-gsuite-govuk-paas/
-          inputs:
-            - name: gsuite-splunk-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: gsuite-splunk-image-git/gds-gsuite-govuk-paas/
+        inputs:
+          - name: gsuite-splunk-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -511,16 +474,12 @@ jobs:
         trigger: true
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: salesforce-splunk-image-git/gds-salesforce-forwarder-paas/
-          inputs:
-            - name: salesforce-splunk-image-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: salesforce-splunk-image-git/gds-salesforce-forwarder-paas/
+          DOCKERFILE: salesforce-splunk-image-git/gds-salesforce-forwarder-paas/Dockerfile
+        inputs:
+          - name: salesforce-splunk-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -553,16 +512,12 @@ jobs:
         trigger: true
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: http-api-resource-git/docker/http-api-resource
-          inputs:
-            - name: http-api-resource-git
-          outputs:
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: http-api-resource-git/docker/http-api-resource
+          DOCKERFILE: http-api-resource-git/docker/http-api-resource/Dockerfile
+        inputs:
+          - name: http-api-resource-git
         on_success:
           <<: *health_status_notify
           params:
@@ -601,17 +556,12 @@ jobs:
 
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: cyber-chalice-git/dockerfiles/chalice/
-          inputs:
-            - name: cyber-chalice-git
-          outputs:
-            - name: cyber-chalice-git # For the tags file
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: cyber-chalice-git/dockerfiles/chalice/
+          DOCKERFILE: cyber-chalice-git/dockerfiles/chalice/Dockerfile
+        inputs:
+          - name: cyber-chalice-git
         on_success:
           <<: *health_status_notify
           params:
@@ -626,7 +576,6 @@ jobs:
       - put: cyber-chalice-image-docker-hub
         params:
           image: image/image.tar
-          additional_tags: cyber-chalice-git/dockerfiles/chalice/tags
         on_success:
           <<: *health_status_notify
           params:
@@ -651,17 +600,12 @@ jobs:
 
       - task: build
         privileged: true
-        config:
-          <<: *build-image-config
-          params:
-            CONTEXT: csw-image-git/dockerfiles/csw/
-          inputs:
-            - name: csw-image-git
-          outputs:
-            - name: cyber-chalice-git # For the tags file
-            - name: image
-          run:
-            path: build
+        file: concourse-base-image-git/build-container.yml
+        params:
+          CONTEXT: csw-image-git/dockerfiles/csw/
+          DOCKERFILE: csw-image-git/dockerfiles/csw/Dockerfile
+        inputs:
+          - name: csw-image-git
         on_success:
           <<: *health_status_notify
           params:
@@ -676,7 +620,6 @@ jobs:
       - put: csw-concourse-worker-image-docker-hub
         params:
           image: image/image.tar
-          additional_tags: csw-image-git/dockerfiles/csw/tags
         on_success:
           <<: *health_status_notify
           params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -615,8 +615,6 @@ jobs:
         params:
           CONTEXT: csw-image-git/dockerfiles/csw/
           DOCKERFILE: csw-image-git/dockerfiles/csw/Dockerfile
-        inputs:
-          - name: csw-image-git
         on_success:
           <<: *health_status_notify
           params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -34,7 +34,7 @@ resources:
   - name: concourse-base-image-pipeline-git
     type: git
     source:
-      branch: master
+      branch: refactor-pipeline-into-tasks
       paths:
         - pipeline.yml
       uri: https://github.com/alphagov/cyber-security-concourse-base-image.git

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -222,6 +222,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: concourse-base-image-git/
@@ -267,6 +268,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: load-testing-image-git/load_testing
@@ -309,6 +311,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-iamge-git/build-container.yml
         params:
           CONTEXT: concourse-base-image-git-amazonlinux2/amazonlinux2
@@ -353,6 +356,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: cloudwatch-health-image-git/docker/concourse-worker-health/
@@ -398,6 +402,8 @@ jobs:
 
       - task: build
         privileged: true
+        file: concourse-base-image-git/build-container.yml
+        config:
         params:
           CONTEXT: csls-image-git/config/concourse/
           DOCKERFILE: csls-image-git/config/concourse/Dockerfile
@@ -436,6 +442,7 @@ jobs:
         trigger: true
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: gsuite-splunk-image-git/gds-gsuite-govuk-paas/
@@ -474,6 +481,7 @@ jobs:
         trigger: true
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: salesforce-splunk-image-git/gds-salesforce-forwarder-paas/
@@ -512,6 +520,7 @@ jobs:
         trigger: true
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: http-api-resource-git/docker/http-api-resource
@@ -556,6 +565,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: cyber-chalice-git/dockerfiles/chalice/
@@ -600,6 +610,7 @@ jobs:
 
       - task: build
         privileged: true
+        config:
         file: concourse-base-image-git/build-container.yml
         params:
           CONTEXT: csw-image-git/dockerfiles/csw/


### PR DESCRIPTION
I've removed the additional tags for the Chalice/CSW containers
They don't make sense.

Currently the CSW image is hard-coded to inherit from tag 2.1
This needs changing to latest separately.