### PR TITLE
Ensure an AWS_DEFAULT_REGION env var is always set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,3 +99,5 @@ RUN wget https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_V
         unzip terraform_${TF_VERSION}_linux_amd64.zip && \
         mv terraform /usr/bin/terraform-${TF_VERSION} && \
         rm terraform_${TF_VERSION}_linux_amd64.zip terraform_${TF_VERSION}_SHA256SUMS
+
+ENV AWS_DEFAULT_REGION eu-west-2


### PR DESCRIPTION
We could choose to overwrite it in a child container or in a specific pipeline task as required but if we don't set it it is always there.