### PR TITLE
CE-258 Handle a recursive copy if artifact source is a directory

### DIFF
--- a/bin/copy_artifacts.py
+++ b/bin/copy_artifacts.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 import argparse
+import errno
 import json
 import os
 import shutil
@@ -76,7 +77,12 @@ def copy_artifact(artifact):
         artifact_root = os.environ[codebuild_src_var]
         source_path = f"{artifact_root}/{artifact['source']}"
         target_path = artifact["target"]
-        created = shutil.copy(source_path, target_path)
+        try:
+            created = shutil.copytree(source_path, target_path)
+        except OSError as error:
+            if error.errno in (errno.ENOTDIR, errno.EINVAL):
+                created = shutil.copy(source_path, target_path)
+            else: raise
         copied = (created == target_path)
     except KeyError as error:
         print(f"Invalid config: {error}")


### PR DESCRIPTION
For things like the ssh config we want to copy in both the deploy key and the ssh config from the `build_ssh_config` module. You could do this with multiple entries in the copy_artifacts list but with this you can just do 

```
copy_artifacts  = [
      {
        artifact = "ssh_config",
        source   = ".ssh"
        target   = "/root/.ssh"
      }
]
```

.. and copy the whole .ssh directory. Then you just have to ensure that `$HOME=/root/` or wherever you've set the target to. 